### PR TITLE
DVX-8295 Add Dockerfile for skyed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+
+!Gemfile
+!Gemfile.lock
+!bin/
+!lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.1.5
+
+RUN mkdir ~/.ssh && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts; gem install bundler
+
+WORKDIR /skyed
+
+COPY Gemfile Gemfile.lock /skyed/
+
+RUN bundle install
+
+COPY . /skyed
+
+ENTRYPOINT ["bin/skyed"]


### PR DESCRIPTION
This allows building a docker container to run skyed and invoke it
passing arguments directly.