### PR TITLE
Rework Dockerfile to use Omnibus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM ruby:2.1.5
+FROM debian:jessie
 
-RUN mkdir ~/.ssh && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts; gem install bundler
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       curl \
+    && curl https://s3.amazonaws.com/skyed/skyed_0.1.16%2B20160825111737.tar.gz > /tmp/skyed_latest.tar.gz \
+    && cd / \
+    && tar xzvf /tmp/skyed_latest.tar.gz \
+    && rm /tmp/skyed_latest.tar.gz \
+    && apt-get purge -y curl ca-certificates \
+    && apt-get autoremove -y
 
-WORKDIR /skyed
+RUN apt-get install -y --no-install-recommends \
+       git \
+       openssh-client \
+    && mkdir ~/.ssh && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
 
-COPY Gemfile Gemfile.lock /skyed/
-
-RUN bundle install
-
-COPY . /skyed
-
-ENTRYPOINT ["bin/skyed"]
+ENTRYPOINT ["/tmp/opt/skyed/bin/skyed"]


### PR DESCRIPTION
The previous Dockerfile showed several issues when trying to use it. The Omnibus path is much more reliable at this point than the original install so embrace it.